### PR TITLE
Fix svg getClosestPoint()

### DIFF
--- a/kute-svg.js
+++ b/kute-svg.js
@@ -62,7 +62,7 @@
     },
     getClosestPoint = function(p,t,s){ // getClosestPoint for polygon paths it returns a close point from the original path (length,pointAtLength,smallest); // intervalLength
       var x, y, a = [], l = s.length, dx, nx, pr;
-      for (i=0; i<l; i++){
+      for (var i=0; i<l; i++){
         x = Math.abs(s[i][0] - t.x);
         y = Math.abs(s[i][1] - t.y);
         a.push( Math.sqrt( x * x + y * y ) );


### PR DESCRIPTION
Changes:
* Add missing `var` in `kute-svg.js` `getClosestPoint()`

Since the svg plugin is written inside of a strict mode function, the global declaration of `i` is causing the following error when invoking `getClosestPoint()` in line [65](https://github.com/thednp/kute.js/blob/master/kute-svg.js#L65):

```
ReferenceError: i is not defined
    at getClosestPoint (http://localhost:4200/vendor.bundle.js:75601:13)
    at Tween.computePathCross (http://localhost:4200/vendor.bundle.js:75692:18)
    at Tween.crossCheck.path (http://localhost:4200/vendor.bundle.js:75738:30)
    at Tween.start (http://localhost:4200/vendor.bundle.js:51842:66)
```

All other `for` loops in this file seem to be ok.

Thanks, great library!

*Side note*: the github editor automatically adds a trailing blank line, let me know if this is an issue and I'll create a different PR without it.